### PR TITLE
Label the image appropriately

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
+        env:
+            FEDORA_VERSION: ${{ matrix.fedora }}
         run: |
-            podman build \
-                -t rustup-toolbox:${{ matrix.fedora }}  \
-                --build-arg=FEDORA_VERSION=${{ matrix.fedora }} .
+            ./build.sh
+            podman inspect rustup-toolbox:$FEDORA_VERSION | jq '.[0].Config.Labels'
 
       - name: Push
         if: ${{ github.ref == 'refs/heads/main' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,18 @@ FROM registry.fedoraproject.org/f$FEDORA_VERSION/fedora-toolbox:$FEDORA_VERSION
 RUN dnf -y update && \
     dnf -y install gcc && \
     dnf clean all
+
 RUN mkdir /cargo && mkdir /rustup
-ENV CARGO_HOME /cargo
-ENV RUSTUP_HOME /rustup
-ENV PATH /cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN curl -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && chmod 0755 /tmp/rustup-init
-RUN /tmp/rustup-init -y --no-modify-path
-RUN rm -f /tmp/rustup-init
+ENV CARGO_HOME=/cargo \
+    RUSTUP_HOME=/rustup \
+    PATH=/cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
-RUN chgrp -R wheel /cargo /rustup
-RUN chmod -R g=u /cargo /rustup
+RUN curl -o /tmp/rustup-init https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init && \
+    chmod 0755 /tmp/rustup-init && \
+    /tmp/rustup-init -y --no-modify-path && \
+    rm -f /tmp/rustup-init
+
+RUN chgrp -R wheel /cargo /rustup && \
+    chmod -R g=u /cargo /rustup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
-ARG FEDORA_VERSION=33
+ARG FEDORA_VERSION
 FROM registry.fedoraproject.org/f$FEDORA_VERSION/fedora-toolbox:$FEDORA_VERSION
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL authoritative-source-url=quay.io \
+      build-date="$BUILD_DATE" \
+      maintainer="Owen Taylor <otaylor@fishsoup.net>" \
+      name=owtaylor/rustup-toolbox \
+      summary="Toolbox container based on Fedora with rustup" \
+      url="https://github.com/owtaylor/rustup-toolbox/" \
+      usage="This image is meant to be used with the toolbox command" \
+      vcs-ref="$VCS_REF" \
+      vcs-url="https://github.com/owtaylor/rustup-toolbox/"
 
 RUN dnf -y update && \
     dnf -y install gcc && \

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -x
+
+FEDORA_VERSION=${FEDORA_VERSION:-33}
+podman build \
+       -t rustup-toolbox:$FEDORA_VERSION  \
+       --build-arg=FEDORA_VERSION=$FEDORA_VERSION \
+       --build-arg=BUILD_DATE="$(date  --rfc-3339=seconds)" \
+       --build-arg VCS_REF="$(git rev-parse HEAD)" \
+       .


### PR DESCRIPTION
Override labels inherited from fedora-toolbox with more appropriate values;
add a script so that we can set vcs-ref and build-date.
